### PR TITLE
Fix codelists

Removing empty columns, leading and trailing whitespace, extra quoting characters, and/or adding missing quoting characters, closing newline

### DIFF
--- a/codelists/+partyRole.csv
+++ b/codelists/+partyRole.csv
@@ -1,2 +1,2 @@
-Category,Code,Title_en,Description_en,Source,
-,enquirer,Enquirer,A party who has made an enquiry during the enquiry phase of a contracting process,,
+Code,Title_en,Description_en
+enquirer,Enquirer,A party who has made an enquiry during the enquiry phase of a contracting process


### PR DESCRIPTION
open-contracting/standard-maintenance-scripts#6