### PR TITLE
make enquiry.id required

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 ### Unreleased
 
 * Remove the `+partyRole.csv` codelist, whose codes already exist in OCDS 1.1
-* Make `enquiry.id` a required field for identifier merge
+* Make `Enquiry.id` a required field for identifier merge
 
 ### v1.1.5
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 ### Unreleased
 
 * Remove the `+partyRole.csv` codelist, whose codes already exist in OCDS 1.1
-* Make `Enquiry.id` a required field for identifier merge
+* Make `Enquiry.id` required so that enquiries are merged by identifier
 
 ### v1.1.5
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 ### Unreleased
 
 * Remove the `+partyRole.csv` codelist, whose codes already exist in OCDS 1.1
+* Make `enquiry.id` a required field for identifier merge
 
 ### v1.1.5
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -20,13 +20,15 @@
       "type": "object",
       "title": "Enquiry",
       "description": "A question related to this contracting process, generally sent during the enquiry period.",
+      "required": [
+        "id"
+      ],
       "properties": {
         "id": {
           "title": "Identifier",
           "description": "A unique identifier for the enquiry.",
           "type": [
-            "string",
-            "null"
+            "string"
           ]
         },
         "date": {


### PR DESCRIPTION
related to https://github.com/open-contracting/ocds-extensions/issues/83.

I wasn't sure if this was the change that was being requested or if it was the make `wholeListMerge` explicit by adding `wholeListMerge: true`?